### PR TITLE
修复安装 MySQL-Python 可能报错的问题

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,7 +7,7 @@ LABEL Name="fisco-bcos-browser 2.0"
 LABEL Description="Oracle Jre 8 + gradle 5.2.1"
 
 # python package
-RUN apt-get update && apt-get install -y python-pip libmysqlclient-dev && pip install MySQL-python requests
+RUN apt-get update && apt-get install -y libffi-dev g++ libssl-dev python-pip libmysqlclient-dev && pip install MySQL-python requests
 
 RUN git clone https://github.com/FISCO-BCOS/fisco-bcos-browser.git /fisco-bcos-browser
 


### PR DESCRIPTION
因为系统依赖原因，修复可能报 `command 'x86_64-linux-gnu-gcc' failed with exit status 1` 错误的问题