### PR TITLE
更新后端 Dockerfile 以兼容新版浏览器

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,10 +10,8 @@ LABEL Description="Oracle Jre 8 + gradle 5.2.1"
 RUN sed -i 's/archive.ubuntu.com/mirrors.cloud.tencent.com/g' /etc/apt/sources.list \
     && sed -i 's/security.ubuntu.com/mirrors.cloud.tencent.com/g' /etc/apt/sources.list \
     && apt-get update \
-    && apt-get install -y python-pip libmysqlclient-dev \
-    && python -m pip install --upgrade pip \
-    && pip install -i https://pypi.douban.com/simple module_name\
-    && pip install MySQL-python requests
+    && apt-get install -y python3-pip \
+    && pip3 install PyMySQL
 
 
 RUN git clone https://github.com/FISCO-BCOS/fisco-bcos-browser.git /fisco-bcos-browser


### PR DESCRIPTION
截止 [65864b7](https://github.com/FISCO-BCOS/fisco-bcos-browser/commits/65864b75d23817c05d4c6aab870f57809a667380)
* 浏览器已经升级为 python3
* MySQL 客户端已经替换为 PyMySQL